### PR TITLE
Transition stat function tests to pytest.

### DIFF
--- a/ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py
+++ b/ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py
@@ -1,207 +1,259 @@
-import math
+import pytest
 
 from ama_xiv_combat_sim.simulator.calcs.stat_fns import StatFns
-from ama_xiv_combat_sim.simulator.testing.test_class import TestClass
 
-#TODO: fdetdh test
-class TestStatFns(TestClass):
-  @TestClass.is_a_test
-  def get_time_using_speed_stat_test(self):
-    test_passed = True
-    err_msg=""
+TEST_DATA = {
+    'fAP': {
+        'Test 1 - No tank': {
+            'args': [390],
+            'kwargs': {'is_tank': False},
+            'expected': 100,
+        },
+        'Test 2 - No tank': {
+            'args': [699],
+            'kwargs': {'is_tank': False},
+            'expected': 254,
+        },
+        'Test 3 - No tank': {
+            'args': [1219],
+            'kwargs': {'is_tank': False},
+            'expected': 514
+        },
+        'Test 1 - Tank': {
+            'args': [390],
+            'kwargs': {'is_tank': True},
+            'expected': 100,
+        },
+        'Test 2 - Tank': {
+            'args': [699],
+            'kwargs': {'is_tank': True},
+            'expected': 223,
+        },
+        'Test 3 - Tank': {
+            'args': [1219],
+            'kwargs': {'is_tank': True},
+            'expected': 431
+        }
+    },
+    'fAuto': {
+        'Test 1': {
+            'args': [120, 3.44, 105],
+            'expected': 183,
+        },
+        'Test 2': {
+            'args': [126, 2.6, 115],
+            'expected': 147,
+        },
+    },
+    'fDet': {
+        'Test 1': {
+            'args': [390],
+            'expected': 1000,
+        },
+        'Test 2': {
+            'args': [566],
+            'expected': 1012,
+        },
+        'Test 3': {
+            'args': [567],
+            'expected': 1013,
+        },
+        'Test 4': {
+            'args': [1706],
+            'expected': 1096,
+        },
+        'Test 5': {
+            'args': [1707],
+            'expected': 1097,
+        },
+        'Test 6': {
+            'args': [1708],
+            'expected': 1097,
+        },
+    },
+    'fDetDH': {
+        'Test 1': {
+            'args': [390, 400],
+            'expected': 1000,
+        },
+        'Test 2': {
+            'args': [1706, 1360],
+            'expected': 1096+70,
+        },
+        'Test 3': {
+            'args': [1707, 1369],
+            'expected': 1097 + 71,
+        },
+    },
+    'fSpd': {
+        'Test 1': {
+            'args': [859],
+            'expected': 1031,
+        },
+        'Test 2': {
+            'args': [1700],
+            'expected': 1088,
+        },
+    },
+    'fTnc': {
+        'Test 1': {
+            'args': [751],
+            'expected': 1018,
+        },
+        'Test 2': {
+            'args': [1100],
+            'expected': 1036,
+        },
+        'Test 3': {
+            'args': [500],
+            'expected': 1005,
+        }
+    },
+    'fWD': {
+        'Test 1': {
+            'args': [120, 100],
+            'expected': 159,
+        },
+        'Test 2': {
+            'args': [126, 115],
+            'expected': 170,
+        },
+    },
+    'get_crit_stats': {
+        'Test 1': {
+            'args': [400],
+            'expected': (0.05, 0.40),
+        },
+        'Test 2': {
+            'args': [475],
+            'expected': (0.057, 0.407),
+        },
+        'Test 3': {
+            'args': [476],
+            'expected': (0.058, 0.408),
+        },
+        'Test 4': {
+            'args': [1150],
+            'expected': (0.128, 0.478),
+        },
+        'Test 5': {
+            'args': [1151],
+            'expected': (0.129, 0.479),
+        },
+        'Test 6': {
+            'args': [1152],
+            'expected': (0.129, 0.479),
+        },
+    },
+    'get_dh_rate': {
+        'Test 1': {
+            'args': [400],
+            'expected': 0,
+        },
+        'Test 2': {
+            'args': [472],
+            'expected': 0.020,
+        },
+        'Test 3': {
+            'args': [473],
+            'expected': 0.021,
+        },
+        'Test 4': {
+            'args': [1360],
+            'expected': 0.277,
+        },
+        'Test 5': {
+            'args': [1361],
+            'expected': 0.278,
+        },
+        'Test 6': {
+            'args': [1362],
+            'expected': 0.278,
+        },
+    },
+    'get_time_using_speed_stat': {
+        'Test 1': {
+            'args': [2500, 1408],
+            'expected': 2330,
+        },
+        'Test 2': {
+            'args': [2500, 1409],
+            'expected': 2320,
+        },
+        'Test 3': {
+            'args': [2500, 1410],
+            'expected': 2320,
+        },
+        'Test 4': {
+            'args': [3500, 999],
+            'expected': 3360,
+        },
+        'Test 5': {
+            'args': [3500, 1000],
+            'expected': 3350,
+        },
+        'Test 6': {
+            'args': [3500, 1001],
+            'expected': 3350,
+        },
+    },
+}
 
-    gcd_inputs_and_expcted= {2500: ((1408, 1409, 1410), (2330, 2320, 2320)),
-                             3500: ((999, 1000, 1001), (3360, 3350, 3350))}
 
-    for gcd_time, inputs_and_outputs in gcd_inputs_and_expcted.items():
-      speed_stat = inputs_and_outputs[0]
-      expected = inputs_and_outputs[1]
-      for i in range(0, len(speed_stat)):
-          gcd_actual = StatFns.get_time_using_speed_stat(gcd_time, speed_stat[i])
-          gcd_expected = expected[i]
-          if gcd_actual != gcd_expected:
-            err_msg += "gcd_time expected: {}. Actual: {}. For {} gcd.\n".format(gcd_expected, gcd_actual, gcd_time)
-            test_passed = False
+def _run_function_test(test: dict, function: callable) -> None:
+    """Runs a test case against the specified function."""
+    expected = test.get('expected')
+    args = test.get('args') or []
+    kwargs = test.get('kwargs') or {}
+    result = function(*args, **kwargs)
+    assert result == expected, f'Expected: {expected}. Actual: {result}'
 
-    return test_passed, err_msg
 
-  @TestClass.is_a_test
-  def get_crit_stats_test(self):
-    test_passed = True
-    err_msg=""
+@pytest.mark.parametrize('test', TEST_DATA['fAP'].values(), ids=TEST_DATA['fAP'])
+def test_statfns_fap(test: dict):
+    _run_function_test(test, StatFns.fAP)
 
-    crit_stat_inputs_and_expected = {400: (0.05, 0.40),
-                                     475: (0.057, 0.407),
-                                     476: (0.058, 0.408),
-                                     1150: (0.128, 0.478),
-                                     1151: (0.129, 0.479),
-                                     1152: (0.129, 0.479)}
 
-    for crit_stat, expected in crit_stat_inputs_and_expected.items():
-      #TODO: consider using math.isclose isntead for float comparison fiddliness.
-      crit_rate_actual, crit_bonus_actual = StatFns.get_crit_stats(crit_stat)
-      if (crit_rate_actual, crit_bonus_actual) != expected:
-        err_msg += "crit stat: {}. crit rate/bonus expected: {}/{}. Actual: {}/{}.\n".format(crit_stat, expected[0], expected[1], crit_rate_actual, crit_bonus_actual)
-        test_passed = False
+@pytest.mark.parametrize('test', TEST_DATA['fAuto'].values(), ids=TEST_DATA['fAuto'])
+def test_statfns_fauto(test: dict):
+    _run_function_test(test, StatFns.fAuto)
 
-    return test_passed, err_msg
 
-  @TestClass.is_a_test
-  def fDetDH_test(self):
-    test_passed = True
-    err_msg=""
+@pytest.mark.parametrize('test', TEST_DATA['fDet'].values(), ids=TEST_DATA['fDet'])
+def test_statfns_fdet(test: dict):
+    _run_function_test(test, StatFns.fDet)
 
-    #(det_stat, dh_stat, fDetDh_expected)
-    stat_inputs_and_expected = ((390, 400, 1000+0),
-                                (1706, 1360, 1096+70),
-                                (1707, 1369, 1097+71))
 
-    for (det_stat, dh_stat, expected) in stat_inputs_and_expected:
-      fDetDH_actual = StatFns.fDetDH(det_stat, dh_stat)
-      if fDetDH_actual != expected:
-        err_msg += "fDetDh expected: {}. Actual: {}.\n".format(expected, fDetDH_actual)
-        test_passed = False
+@pytest.mark.parametrize('test', TEST_DATA['fDetDH'].values(), ids=TEST_DATA['fDetDH'])
+def test_statfns_fdetdh(test: dict):
+    _run_function_test(test, StatFns.fDetDH)
 
-    return test_passed, err_msg
 
-  @TestClass.is_a_test
-  def fDet_test(self):
-    test_passed = True
-    err_msg=""
+@pytest.mark.parametrize('test', TEST_DATA['fSpd'].values(), ids=TEST_DATA['fSpd'])
+def test_statfns_fspd(test: dict):
+    _run_function_test(test, StatFns.fSpd)
 
-    det_stat_inputs_and_expected = {390: 1000,
-                                    566: 1012,
-                                    567: 1013,
-                                    1706: 1096,
-                                    1707: 1097,
-                                    1708: 1097}
 
-    for det_stat, expected in det_stat_inputs_and_expected.items():
-      fDet_actual = StatFns.fDet(det_stat)
-      if fDet_actual != expected:
-        err_msg += "fDet expected: {}. Actual: {}.\n".format(expected, fDet_actual)
-        test_passed = False
+@pytest.mark.parametrize('test', TEST_DATA['fTnc'].values(), ids=TEST_DATA['fTnc'])
+def test_statfns_ftnc(test: dict):
+    _run_function_test(test, StatFns.fTnc)
 
-    return test_passed, err_msg
 
-  @TestClass.is_a_test
-  def dh_rate_test(self):
-    test_passed = True
-    err_msg=""
+@pytest.mark.parametrize('test', TEST_DATA['fWD'].values(), ids=TEST_DATA['fWD'])
+def test_statfns_fwd(test: dict):
+    _run_function_test(test, StatFns.fWD)
 
-    dh_stat_inputs_and_expected = {400: 0,
-                                   472: 0.020,
-                                   473: 0.021,
-                                   1360: 0.277,
-                                   1361: 0.278,
-                                   1362: 0.278}
 
-    for dh_stat, expected in dh_stat_inputs_and_expected.items():
-      dh_rate_actual = StatFns.get_dh_rate(dh_stat)
-      if not math.isclose(dh_rate_actual, expected, abs_tol=1e-4):
-        err_msg += "dh_rate expected: {}. Actual: {}.\n".format(expected, dh_rate_actual)
-        test_passed = False
+@pytest.mark.parametrize('test', TEST_DATA['get_dh_rate'].values(), ids=TEST_DATA['get_dh_rate'])
+def test_statfns_get_dh_rate(test: dict):
+    _run_function_test(test, StatFns.get_dh_rate)
 
-    return test_passed, err_msg
 
-  @TestClass.is_a_test
-  def wd_test(self):
-    test_passed = True
-    err_msg=""
+@pytest.mark.parametrize('test', TEST_DATA['get_crit_stats'].values(), ids=TEST_DATA['get_crit_stats'])
+def test_statfns_get_crit_stats(test: dict):
+    _run_function_test(test, StatFns.get_crit_stats)
 
-    #(wd, job_mod, fWd_expected)
-    wd_stat_inputs_and_expected = ((120, 100, 159),
-                                   (126, 115, 170))
 
-    for (wd, job_mod, expected) in wd_stat_inputs_and_expected:
-      fWD_actual = StatFns.fWD(wd, job_mod)
-      if fWD_actual != expected:
-        err_msg += "fWd expected: {}. Actual: {}.\n".format(expected, fWD_actual)
-        test_passed = False
-
-    return test_passed, err_msg
-
-  @TestClass.is_a_test
-  def fAuto_test(self):
-    test_passed = True
-    err_msg=""
-
-    stat_inputs_and_expected = ((120, 3.44, 105, 183),
-                                (126, 2.6, 115, 147))
-
-    for (wd, weapon_delay, job_mod, expected) in stat_inputs_and_expected:
-      fAuto_actual = StatFns.fAuto(wd, weapon_delay, job_mod)
-      if fAuto_actual != expected:
-        err_msg += "fAuto expected: {}. Actual: {}.\n".format(expected, fAuto_actual)
-        test_passed = False
-
-    return test_passed, err_msg
-
-  @TestClass.is_a_test
-  def spd_test(self):
-    test_passed = True
-    err_msg=""
-
-    #(spd, fSpd_expected)
-    spd_stat_inputs_and_expected = ((859, 1031),
-                                    (1700,  1088))
-
-    for (spd, expected) in spd_stat_inputs_and_expected:
-      fSpd_actual_actual = StatFns.fSpd(spd)
-      if fSpd_actual_actual != expected:
-        err_msg += "fSpd expected: {}. Actual: {}.\n".format(expected, fSpd_actual_actual)
-        test_passed = False
-
-    return test_passed, err_msg
-
-  @TestClass.is_a_test
-  def fTnc_test(self):
-    test_passed = True
-    err_msg=""
-
-    tnc_inputs_and_expected = {751: 1018,
-                               1100: 1036,
-                               500: 1005}
-
-    for tnc, expected in tnc_inputs_and_expected.items():
-      fTnc_actual = StatFns.fTnc(tnc)
-      if fTnc_actual != expected:
-        err_msg += "fTnc expected: {}. Actual: {}.\n".format(expected, fTnc_actual)
-        test_passed = False
-
-    return test_passed, err_msg
-
-  @TestClass.is_a_test
-  def fAP_tank_test(self):
-    test_passed = True
-    err_msg=""
-
-    ap_inputs_and_expected = {390: 100,
-                              699: 223,
-                              1219: 431}
-
-    for ap, expected in ap_inputs_and_expected.items():
-      fAP_actual = StatFns.fAP(ap, is_tank = True)
-      if fAP_actual != expected:
-        err_msg += "fAP expected: {}. Actual: {}.\n".format(expected, fAP_actual)
-        test_passed = False
-
-    return test_passed, err_msg
-
-  @TestClass.is_a_test
-  def fAP_non_tank_test(self):
-    test_passed = True
-    err_msg=""
-
-    ap_inputs_and_expected = {390: 100,
-                              699: 254,
-                              1219: 514}
-
-    for ap, expected in ap_inputs_and_expected.items():
-      fAP_actual = StatFns.fAP(ap, is_tank = False)
-      if fAP_actual != expected:
-        err_msg += "fAP expected: {}. Actual: {}.\n".format(expected, fAP_actual)
-        test_passed = False
-
-    return test_passed, err_msg
-
+@pytest.mark.parametrize('test', TEST_DATA['get_time_using_speed_stat'].values(), ids=TEST_DATA['get_time_using_speed_stat'])
+def test_statfns_get_time_using_speed_stat(test: dict):
+    _run_function_test(test, StatFns.get_time_using_speed_stat)


### PR DESCRIPTION
This is just a proof of concept of using pytest for testing instead of custom classes.
The advantages being the ability to configure global per-project testing settings, monkeypatches and generating metrics such as runtime, coverage and so on.

Example:

```
pytest -vv ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_fap[Test 1 - No tank] PASSED                    [  2%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_fap[Test 2 - No tank] PASSED                    [  4%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_fap[Test 3 - No tank] PASSED                    [  7%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_fap[Test 1 - Tank] PASSED                       [  9%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_fap[Test 2 - Tank] PASSED                       [ 11%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_fap[Test 3 - Tank] PASSED                       [ 14%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_fauto[Test 1] PASSED                            [ 16%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_fauto[Test 2] PASSED                            [ 19%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_fdet[Test 1] PASSED                             [ 21%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_fdet[Test 2] PASSED                             [ 23%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_fdet[Test 3] PASSED                             [ 26%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_fdet[Test 4] PASSED                             [ 28%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_fdet[Test 5] PASSED                             [ 30%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_fdet[Test 6] PASSED                             [ 33%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_fdetdh[Test 1] PASSED                           [ 35%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_fdetdh[Test 2] PASSED                           [ 38%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_fdetdh[Test 3] PASSED                           [ 40%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_fspd[Test 1] PASSED                             [ 42%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_fspd[Test 2] PASSED                             [ 45%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_ftnc[Test 1] PASSED                             [ 47%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_ftnc[Test 2] PASSED                             [ 50%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_ftnc[Test 3] PASSED                             [ 52%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_fwd[Test 1] PASSED                              [ 54%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_fwd[Test 2] PASSED                              [ 57%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_get_dh_rate[Test 1] PASSED                      [ 59%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_get_dh_rate[Test 2] PASSED                      [ 61%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_get_dh_rate[Test 3] PASSED                      [ 64%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_get_dh_rate[Test 4] PASSED                      [ 66%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_get_dh_rate[Test 5] PASSED                      [ 69%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_get_dh_rate[Test 6] PASSED                      [ 71%]
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_get_crit_stats[Test 1] PASSED                   [ 73%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_get_crit_stats[Test 2] PASSED                   [ 76%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_get_crit_stats[Test 3] PASSED                   [ 78%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_get_crit_stats[Test 4] PASSED                   [ 80%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_get_crit_stats[Test 5] PASSED                   [ 83%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_get_crit_stats[Test 6] PASSED                   [ 85%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_get_time_using_speed_stat[Test 1] PASSED        [ 88%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_get_time_using_speed_stat[Test 2] PASSED        [ 90%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_get_time_using_speed_stat[Test 3] PASSED        [ 92%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_get_time_using_speed_stat[Test 4] PASSED        [ 95%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_get_time_using_speed_stat[Test 5] PASSED        [ 97%] 
ama_xiv_combat_sim/simulator/calcs/test_stat_fns.py::test_statfns_get_time_using_speed_stat[Test 6] PASSED        [100%] 

================================================== 42 passed in 0.12s ================================================== 
```

This can also be easily integrated into a GH action to catch breaking changes before merge.